### PR TITLE
IPC Updates & Minor Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.o
 .vgcore.*
+.cache
+compile_commands.json
 bin/
 obj/

--- a/include/spotify-listener.h
+++ b/include/spotify-listener.h
@@ -12,7 +12,7 @@
  *
  * @returns dbus_bool_t TRUE if messages successfully sent, FALSE otherwise.
  */
-dbus_bool_t send_ipc_polybar(int numOfMsgs, ...);
+dbus_bool_t polybar_msg(int numOfMsgs, ...);
 
 /**
  * DBus handler function for PropertiesChanged signals. This is automatically

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,11 @@
 CC = gcc
-LIBS := dbus-1
-CFLAGS = $(shell pkg-config --cflags dbus-1)
+LIBS := dbus-1 gio-2.0 glib-2.0
+CFLAGS = $(shell pkg-config --cflags --libs dbus-1 gio-2.0 glib-2.0)
 
 LIBS_INC := $(foreach lib,$(LIBS),-l$(lib))
 
 PKG_NAME = polybar-spotify-module
-BASE_INSTALL_PREFIX = 
+BASE_INSTALL_PREFIX =
 
 IDIR = ../include
 ODIR = ../obj
@@ -43,7 +43,7 @@ all: spotifyctl spotify-listener
 debug: spotifyctl spotify-listener
 
 install: spotifyctl spotify-listener
-	install -Dm755 -t $(BASE_INSTALL_PREFIX)$(BIN_INSTALL_DIR) $(EXES) 
+	install -Dm755 -t $(BASE_INSTALL_PREFIX)$(BIN_INSTALL_DIR) $(EXES)
 	install -Dm644 $(LICENSE_FILE) $(BASE_INSTALL_PREFIX)$(LICENSE_INSTALL_PATH)
 	install -Dm644 $(README_FILE) $(BASE_INSTALL_PREFIX)$(README_INSTALL_PATH)
 	install -Dm644 $(SERVICE_FILE_NAME) $(BASE_INSTALL_PREFIX)$(SERVICE_INSTALL_PATH)
@@ -76,4 +76,3 @@ $(ODIR)/%.o: %.c $(DEPS) $(EXE_DEPS)
 
 clean:
 	rm -f $(ODIR)/*.o *~ core vgcore.* $(IDIR)/*~ $(BIN_DIR)/*
-

--- a/src/spotify-listener.c
+++ b/src/spotify-listener.c
@@ -58,9 +58,8 @@ dbus_bool_t update_last_trackid(const char *trackid) {
       CURRENT_SPOTIFY_STATE = PLAYING;
       return TRUE;
     }
-  } else {
-    return FALSE;
   }
+    return FALSE;
 }
 
 dbus_bool_t spotify_update_track(const char *current_trackid) {

--- a/src/spotify-listener.c
+++ b/src/spotify-listener.c
@@ -49,10 +49,15 @@ dbus_bool_t update_last_trackid(const char *trackid) {
 
     last_trackid = (char *)realloc(last_trackid, size);
     last_trackid[0] = '\0';
-
     strcpy(last_trackid, trackid);
 
-    return TRUE;
+
+    if (polybar_msg(4, "#playpause.hook.1",
+          "#previous.hook.1", "#next.hook.1",
+          "#spotify.hook.1")) {
+      CURRENT_SPOTIFY_STATE = PLAYING;
+      return TRUE;
+    }
   } else {
     return FALSE;
   }

--- a/src/spotify-listener.c
+++ b/src/spotify-listener.c
@@ -7,6 +7,7 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <syslog.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -64,12 +65,12 @@ dbus_bool_t get_spotify_status() {
 	g_assert_no_error(error);
 
 	/* read the player property of the interface */
-	variant = g_dbus_proxy_get_cached_property(proxy, "Identity");
-  if(variant == NULL){
-    printf("Error in getting current mpris player.");
-    return FALSE;
+  variant = g_dbus_proxy_get_cached_property(proxy, "Identity");
+
+  g_assert(variant != NULL);
+  if(g_variant_is_of_type(variant, G_VARIANT_TYPE_STRING) == TRUE){
+    g_variant_get(variant, "s", &info);
   }
-	g_variant_get(variant, "s", &info);
 
 	g_variant_unref(variant);
 	printf("Current mpris media player is: %s\n", info);
@@ -432,7 +433,7 @@ int main() {
   is_spotify = get_spotify_status();
 
   if (is_spotify) {
-    printf("Current track: %s\n", get_now_playing());
+    update_last_trackid(get_now_playing());
   }
 
   // Receive messages for PropertiesChanged signal to detect track changes

--- a/src/spotify-listener.c
+++ b/src/spotify-listener.c
@@ -1,12 +1,14 @@
 #include "../include/spotify-listener.h"
 
 #include <dbus-1.0/dbus/dbus.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 #include "../include/utils.h"
 
@@ -16,7 +18,7 @@ const dbus_bool_t VERBOSE = TRUE;
 const dbus_bool_t VERBOSE = FALSE;
 #endif
 
-const char *POLYBAR_IPC_DIRECTORY = "/tmp";
+// const char *POLYBAR_IPC_DIRECTORY = "/tmp";
 
 // Used to check if track has changed
 char *last_trackid = NULL;
@@ -30,331 +32,333 @@ SpotifyState CURRENT_SPOTIFY_STATE = EXITED;
 
 // DBus signals to listen for
 const char *PROPERTIES_CHANGED_MATCH =
-    "interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',"
-    "path='/org/mpris/MediaPlayer2'";
+"interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',"
+"path='/org/mpris/MediaPlayer2'";
 const char *NAME_OWNER_CHANGED_MATCH =
-    "interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/"
-    "freedesktop/DBus'";
+"interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/"
+"freedesktop/DBus'";
 
 
 dbus_bool_t update_last_trackid(const char *trackid) {
-    if (trackid != NULL) {
-        // +1 for null char
-        size_t size = strlen(trackid) + 1;
+  if (trackid != NULL) {
+    // +1 for null char
+    size_t size = strlen(trackid) + 1;
 
-        last_trackid = (char *)realloc(last_trackid, size);
-        last_trackid[0] = '\0';
+    last_trackid = (char *)realloc(last_trackid, size);
+    last_trackid[0] = '\0';
 
-        strcpy(last_trackid, trackid);
+    strcpy(last_trackid, trackid);
 
-        return TRUE;
-    } else {
-        return FALSE;
-    }
+    return TRUE;
+  } else {
+    return FALSE;
+  }
 }
 
 dbus_bool_t spotify_update_track(const char *current_trackid) {
-    // If trackid didn't change
-    if (last_trackid != NULL && strcmp(current_trackid, last_trackid) != 0) {
-        puts("Track Changed");
-        // Send message to update track name
-        if (send_ipc_polybar(1, "hook:module/spotify2")) return TRUE;
-    }
-    return FALSE;
+  // If trackid didn't change
+  if (last_trackid != NULL && strcmp(current_trackid, last_trackid) != 0) {
+    puts("Track Changed");
+    // Send message to update track name
+    if (polybar_msg(1, "#spotify.hook.1")) return TRUE;
+  }
+  return FALSE;
 }
 
 dbus_bool_t spotify_update_sender(const char *senderid) {
-    if (senderid != NULL) {
-        // +1 for null char
-        size_t size = strlen(senderid) + 1;
+  if (senderid != NULL) {
+    // +1 for null char
+    size_t size = strlen(senderid) + 1;
 
-        dbus_senderid = (char *)realloc(dbus_senderid, size);
-        dbus_senderid[0] = '\0';
+    dbus_senderid = (char *)realloc(dbus_senderid, size);
+    dbus_senderid[0] = '\0';
 
-        strcpy(dbus_senderid, senderid);
+    strcpy(dbus_senderid, senderid);
 
-        return TRUE;
-    } else {
-        return FALSE;
-    }
+    return TRUE;
+  } else {
+    return FALSE;
+  }
 }
 
 dbus_bool_t spotify_playing() {
-    if (CURRENT_SPOTIFY_STATE != PLAYING) {
-        puts("Song is playing");
-        // Show pause, next, and previous button on polybar
-        if (send_ipc_polybar(4, "hook:module/playpause2",
-                             "hook:module/previous2", "hook:module/next2",
-                             "hook:module/spotify2")) {
-            CURRENT_SPOTIFY_STATE = PLAYING;
-            return TRUE;
-        }
+  if (CURRENT_SPOTIFY_STATE != PLAYING) {
+    puts("Song is playing");
+    // Show pause, next, and previous button on polybar
+    if (polybar_msg(4, "#playpause.hook.1",
+          "#previous.hook.1", "#next.hook.1",
+          "#spotify.hook.1")) {
+      CURRENT_SPOTIFY_STATE = PLAYING;
+      return TRUE;
     }
-    return FALSE;
+  }
+  return FALSE;
 }
 
 dbus_bool_t spotify_paused() {
-    if (CURRENT_SPOTIFY_STATE != PAUSED) {
-        puts("Song is paused");
-        // Show play, next, and previous button on polybar
-        if (send_ipc_polybar(4, "hook:module/playpause3",
-                             "hook:module/previous2", "hook:module/next2",
-                             "hook:module/spotify2")) {
-            CURRENT_SPOTIFY_STATE = PAUSED;
-            return TRUE;
-        }
+  if (CURRENT_SPOTIFY_STATE != PAUSED) {
+    puts("Song is paused");
+    // Show play, next, and previous button on polybar
+    if (polybar_msg(4, "#playpause.hook.2",
+          "#previous.hook.1", "#nest.hook.1",
+          "#spotify.hook.1")) {
+      CURRENT_SPOTIFY_STATE = PAUSED;
+      return TRUE;
     }
-    return FALSE;
+  }
+  return FALSE;
 }
 
 dbus_bool_t spotify_exited() {
-    if (CURRENT_SPOTIFY_STATE != EXITED) {
-        // Hide all buttons and track display on polybar
-        if (send_ipc_polybar(4, "hook:module/playpause1",
-                             "hook:module/previous1", "hook:module/next1",
-                             "hook:module/spotify1")) {
-            CURRENT_SPOTIFY_STATE = EXITED;
-            return TRUE;
-        }
+  if (CURRENT_SPOTIFY_STATE != EXITED) {
+    // Hide all buttons and track display on polybar
+    if (polybar_msg(4, "#playpause.hook.0",
+          "#previous.hook.0", "#next.hook.0",
+          "#spotify.hook.0")) {
+      CURRENT_SPOTIFY_STATE = EXITED;
+      return TRUE;
     }
-    return FALSE;
+  }
+  return FALSE;
 }
 
-dbus_bool_t send_ipc_polybar(int numOfMsgs, ...) {
-    char **paths;
-    size_t num_of_paths;
-    va_list args;
+dbus_bool_t polybar_msg(int numOfMsgs, ...) {
+  va_list args;
 
-    // Pass address of pointer to array of strings
-    get_polybar_ipc_paths(POLYBAR_IPC_DIRECTORY, &paths, &num_of_paths);
+  va_start(args, numOfMsgs);
+  for (int m = 0; m < numOfMsgs; m++) {
+    char *message = va_arg(args, char *);
+    char *exec_args[]={"polybar-msg","action", message, NULL};
 
-    for (size_t p = 0; p < num_of_paths; p++) {
-        FILE *fp;
-
-        va_start(args, numOfMsgs);
-        for (int m = 0; m < numOfMsgs; m++) {
-            const char *message = va_arg(args, char *);
-
-            fp = fopen(paths[p], "w");
-            fputs(message, fp);
-            printf("%s%s%s%s%s\n", "Sending the message '", message, "' to '",
-                   paths[p], "'");
-
-            fclose(fp);
-
-            // Without sleep, requests are sometimes ignored
-            msleep(10);
-        }
-        va_end(args);
-
-        free(paths[p]);
+    // fork and exec polybar-msg calls for each variadic
+    int pid = fork();
+    if (pid < 0){
+      printf("Fork error, unable to send message to polybar.\n");
+      perror(errno);
+      return FALSE;
     }
+    else if (pid == 0){
+      printf("%s%s%s\n", "Sending the message '", message, "' via "
+          "polybar-msg.\n");
 
-    free(paths);
+      execvp(exec_args[0], exec_args);
 
-    return TRUE;
+      printf("Execvp error, unable to send message to polybar.\n");
+      perror(errno);
+      return FALSE;
+    }
+    else {
+      // Without sleep, requests are sometimes ignored
+      // TODO Unsure if this is still needed. May leave this here since it
+      // shouldn't negatively impact program execution.
+      msleep(10);
+    }
+  }
+  va_end(args);
+
+  return TRUE;
 }
 
 DBusHandlerResult properties_changed_handler(DBusConnection *connection,
-                                             DBusMessage *message,
-                                             void *user_data) {
-    if (VERBOSE) puts("Running properties_changed_handler");
-    DBusMessageIter iter;
-    DBusMessageIter sub_iter;
-    dbus_bool_t is_spotify = FALSE;
-    dbus_message_iter_init(message, &iter);
+    DBusMessage *message,
+    void *user_data) {
+  if (VERBOSE) puts("Running properties_changed_handler");
+  DBusMessageIter iter;
+  DBusMessageIter sub_iter;
+  dbus_bool_t is_spotify = FALSE;
+  dbus_message_iter_init(message, &iter);
 
-    /**
-     * Format of PropertiesChanged signal
-     * string "org.mpris.MediaPlayer2.Player"
-     * array [
-     *     dict entry(
-     *         string "Metadata"
-     *         variant  array [
-     *             dict entry(
-     *                 string "mpris:trackid"
-     *                 variant  string "spotify:track:xxxxxxxxxxxxx"
-     *             )
-     *           .
-     *           .
-     *           .
-     *         ]
-     *     )
-     *     dict entry(
-     *         string "PlaybackStatus"
-     *         variant  string "Paused"
-     *     )
-     * ]
-     *
-     */
+  /**
+   * Format of PropertiesChanged signal
+   * string "org.mpris.MediaPlayer2.Player"
+   * array [
+   *     dict entry(
+   *         string "Metadata"
+   *         variant  array [
+   *             dict entry(
+   *                 string "mpris:trackid"
+   *                 variant  string "spotify:track:xxxxxxxxxxxxx"
+   *             )
+   *           .
+   *           .
+   *           .
+   *         ]
+   *     )
+   *     dict entry(
+   *         string "PlaybackStatus"
+   *         variant  string "Paused"
+   *     )
+   * ]
+   *
+   */
 
-    char *interface_name = iter_get_string(&iter);
+  char *interface_name = iter_get_string(&iter);
 
-    // Check if interface is correct
-    if (interface_name != NULL &&
-        strcmp(interface_name, "org.mpris.MediaPlayer2.Player") != 0) {
-        if (VERBOSE)
-            puts(
-                "Interface of PropertiesChanged signal not "
-                "org.mpris.MediaPlayer2.Player");
-        free(interface_name);
-        return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-    }
+  // Check if interface is correct
+  if (interface_name != NULL &&
+      strcmp(interface_name, "org.mpris.MediaPlayer2.Player") != 0) {
+    if (VERBOSE)
+      puts(
+          "Interface of PropertiesChanged signal not "
+          "org.mpris.MediaPlayer2.Player");
     free(interface_name);
+    return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+  }
+  free(interface_name);
 
-    dbus_message_iter_next(&iter);
+  dbus_message_iter_next(&iter);
 
+  // Recurse into array
+  if (!(recurse_iter_of_type(&iter, &sub_iter, DBUS_TYPE_ARRAY) &&
+        // Go to value with Metadata key
+        iter_try_step_to_key(&sub_iter, "Metadata") &&
+        // Step into variant value
+        iter_try_step_into_type(&sub_iter, DBUS_TYPE_VARIANT) &&
+        // Step into array of metadata
+        iter_try_step_into_signature(&sub_iter, "a{sv}") &&
+        // Go to value with key mpris:trackid
+        iter_try_step_to_key(&sub_iter, "mpris:trackid") &&
+        // Step into container
+        iter_try_step_into_type(&sub_iter, DBUS_TYPE_VARIANT) &&
+        // Verify string type
+        dbus_message_iter_get_arg_type(&sub_iter) == DBUS_TYPE_STRING) &&
+
+      !(recurse_iter_of_type(&iter, &sub_iter, DBUS_TYPE_ARRAY) &&
+        // Go to value with Metadata key
+        iter_try_step_to_key(&sub_iter, "PlaybackStatus") &&
+        // Step into variant value
+        iter_try_step_into_type(&sub_iter, DBUS_TYPE_VARIANT) &&
+        // Verify string type
+        dbus_message_iter_get_arg_type(&sub_iter) == DBUS_TYPE_STRING)) {
+    return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+  }
+
+  // Make sure trackid begins with spotify
+  char *trackid = iter_get_string(&sub_iter);
+  if (trackid != NULL && strncmp(trackid, "/com/spotify", 12) == 0) {
+    spotify_update_sender(dbus_message_get_sender(message));
+    spotify_update_track(trackid);
+    update_last_trackid(trackid);
+    is_spotify = TRUE;
+
+    if (VERBOSE) puts("Spotify Detected");
+  }
+
+  free(trackid);
+
+  if (!is_spotify && dbus_senderid && strcmp(dbus_senderid, dbus_message_get_sender(message)) == 0) {
+    is_spotify = TRUE;
+  }
+
+  if (is_spotify) {
     // Recurse into array
     if (!(recurse_iter_of_type(&iter, &sub_iter, DBUS_TYPE_ARRAY) &&
-          // Go to value with Metadata key
-          iter_try_step_to_key(&sub_iter, "Metadata") &&
-          // Step into variant value
-          iter_try_step_into_type(&sub_iter, DBUS_TYPE_VARIANT) &&
-          // Step into array of metadata
-          iter_try_step_into_signature(&sub_iter, "a{sv}") &&
-          // Go to value with key mpris:trackid
-          iter_try_step_to_key(&sub_iter, "mpris:trackid") &&
-          // Step into container
-          iter_try_step_into_type(&sub_iter, DBUS_TYPE_VARIANT) &&
-          // Verify string type
-          dbus_message_iter_get_arg_type(&sub_iter) == DBUS_TYPE_STRING) &&
-
-          !(recurse_iter_of_type(&iter, &sub_iter, DBUS_TYPE_ARRAY) &&
-          // Go to value with Metadata key
+          // Step to PlaybackStatus key
           iter_try_step_to_key(&sub_iter, "PlaybackStatus") &&
-          // Step into variant value
+          // Recurse into variant value
           iter_try_step_into_type(&sub_iter, DBUS_TYPE_VARIANT) &&
           // Verify string type
           dbus_message_iter_get_arg_type(&sub_iter) == DBUS_TYPE_STRING)) {
-        return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+      return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
     }
 
-    // Make sure trackid begins with spotify
-    char *trackid = iter_get_string(&sub_iter);
-    if (trackid != NULL && strncmp(trackid, "/com/spotify", 12) == 0) {
-        spotify_update_sender(dbus_message_get_sender(message));
-        spotify_update_track(trackid);
-        update_last_trackid(trackid);
-        is_spotify = TRUE;
-
-        if (VERBOSE) puts("Spotify Detected");
+    // Update polybar modules
+    char *status = iter_get_string(&sub_iter);
+    if (strcmp(status, "Paused") == 0) {
+      spotify_paused();
+    } else if (strcmp(status, "Playing") == 0) {
+      spotify_playing();
     }
 
-    free(trackid);
+    free(status);
+  }
 
-    if (!is_spotify && dbus_senderid && strcmp(dbus_senderid, dbus_message_get_sender(message)) == 0) {
-        is_spotify = TRUE;
-    }
-
-    if (is_spotify) {
-        // Recurse into array
-        if (!(recurse_iter_of_type(&iter, &sub_iter, DBUS_TYPE_ARRAY) &&
-              // Step to PlaybackStatus key
-              iter_try_step_to_key(&sub_iter, "PlaybackStatus") &&
-              // Recurse into variant value
-              iter_try_step_into_type(&sub_iter, DBUS_TYPE_VARIANT) &&
-              // Verify string type
-              dbus_message_iter_get_arg_type(&sub_iter) == DBUS_TYPE_STRING)) {
-            return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-        }
-
-        // Update polybar modules
-        char *status = iter_get_string(&sub_iter);
-        if (strcmp(status, "Paused") == 0) {
-            spotify_paused();
-        } else if (strcmp(status, "Playing") == 0) {
-            spotify_playing();
-        }
-
-        free(status);
-    }
-
-    return DBUS_HANDLER_RESULT_HANDLED;
+  return DBUS_HANDLER_RESULT_HANDLED;
 }
 
 DBusHandlerResult name_owner_changed_handler(DBusConnection *connection,
-                                             DBusMessage *message,
-                                             void *user_data) {
-    if (VERBOSE) puts("Starting handler for name owner changed");
+    DBusMessage *message,
+    void *user_data) {
+  if (VERBOSE) puts("Starting handler for name owner changed");
 
-    const char *name;
-    const char *old_owner;
-    const char *new_owner;
+  const char *name;
+  const char *old_owner;
+  const char *new_owner;
 
-    /**
-     * Format of NameOwnerChanged signal
-     * string "name"
-     * string "old owner"
-     * string "new owner"
-     *
-     */
+  /**
+   * Format of NameOwnerChanged signal
+   * string "name"
+   * string "old owner"
+   * string "new owner"
+   *
+   */
 
-    // Try to get message arguments
-    if (!dbus_message_get_args(message, NULL, DBUS_TYPE_STRING, &name,
-                               DBUS_TYPE_STRING, &old_owner, DBUS_TYPE_STRING,
-                               &new_owner, DBUS_TYPE_INVALID)) {
-        return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-    }
-
-    // If name matches spotify and new owner is "", spotify disconnected
-    if (strcmp(name, "org.mpris.MediaPlayer2.spotify") == 0 &&
-        strcmp(new_owner, "") == 0) {
-        puts("Spotify disconnected");
-        spotify_exited();
-        return DBUS_HANDLER_RESULT_HANDLED;
-    }
-
+  // Try to get message arguments
+  if (!dbus_message_get_args(message, NULL, DBUS_TYPE_STRING, &name,
+        DBUS_TYPE_STRING, &old_owner, DBUS_TYPE_STRING,
+        &new_owner, DBUS_TYPE_INVALID)) {
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+  }
+
+  // If name matches spotify and new owner is "", spotify disconnected
+  if (strcmp(name, "org.mpris.MediaPlayer2.spotify") == 0 &&
+      strcmp(new_owner, "") == 0) {
+    puts("Spotify disconnected");
+    spotify_exited();
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 }
 
 void free_user_data(void *memory) {}
 
 int main() {
-    DBusConnection *connection;
-    DBusError err;
+  DBusConnection *connection;
+  DBusError err;
 
-    dbus_error_init(&err);
+  dbus_error_init(&err);
 
-    // Connect to session bus
-    if (!(connection = dbus_bus_get(DBUS_BUS_SESSION, &err))) {
-        fputs(err.message, stderr);
-        return 1;
-    }
+  // Connect to session bus
+  if (!(connection = dbus_bus_get(DBUS_BUS_SESSION, &err))) {
+    fputs(err.message, stderr);
+    return 1;
+  }
 
-    // Receive messages for PropertiesChanged signal to detect track changes
-    // or spotify launching
-    dbus_bus_add_match(connection, PROPERTIES_CHANGED_MATCH, &err);
-    if (dbus_error_is_set(&err)) {
-        fputs(err.message, stderr);
-        return 1;
-    }
+  // Receive messages for PropertiesChanged signal to detect track changes
+  // or spotify launching
+  dbus_bus_add_match(connection, PROPERTIES_CHANGED_MATCH, &err);
+  if (dbus_error_is_set(&err)) {
+    fputs(err.message, stderr);
+    return 1;
+  }
 
-    // Receive messages for NameOwnerChanged signal to detect spotify exiting
-    dbus_bus_add_match(connection, NAME_OWNER_CHANGED_MATCH, &err);
-    if (dbus_error_is_set(&err)) {
-        fputs(err.message, stderr);
-        return 1;
-    }
+  // Receive messages for NameOwnerChanged signal to detect spotify exiting
+  dbus_bus_add_match(connection, NAME_OWNER_CHANGED_MATCH, &err);
+  if (dbus_error_is_set(&err)) {
+    fputs(err.message, stderr);
+    return 1;
+  }
 
-    // Register handler for PropertiesChanged signal
-    if (!dbus_connection_add_filter(connection, properties_changed_handler,
-                                    NULL, free_user_data)) {
-        fputs("Failed to add properties changed handler", stderr);
-        return 1;
-    }
+  // Register handler for PropertiesChanged signal
+  if (!dbus_connection_add_filter(connection, properties_changed_handler,
+        NULL, free_user_data)) {
+    fputs("Failed to add properties changed handler", stderr);
+    return 1;
+  }
 
-    // Register handler for NameOwnerChanged signal
-    if (!dbus_connection_add_filter(connection, name_owner_changed_handler,
-                                    NULL, free_user_data)) {
-        fputs("Failed to add NameOwnerChanged handler", stderr);
-        return 1;
-    }
+  // Register handler for NameOwnerChanged signal
+  if (!dbus_connection_add_filter(connection, name_owner_changed_handler,
+        NULL, free_user_data)) {
+    fputs("Failed to add NameOwnerChanged handler", stderr);
+    return 1;
+  }
 
-    // Read messages and call handlers when neccessary
-    while (dbus_connection_read_write_dispatch(connection, -1)) {
-        if (VERBOSE) puts("In dispatch loop");
-    }
+  // Read messages and call handlers when neccessary
+  while (dbus_connection_read_write_dispatch(connection, -1)) {
+    if (VERBOSE) puts("In dispatch loop");
+  }
 
-    dbus_connection_unref(connection);
-    return 0;
+  dbus_connection_unref(connection);
+  return 0;
 }

--- a/src/spotify-listener.service
+++ b/src/spotify-listener.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=A program that monitors Spotify DBus signals and communicates with polybar over IPC to control the polybar spotify modules.
+Description=A program that monitors Spotify DBus signals and communicates with polybar over dbus to update the module and control spotify.
 After=graphical.target
 
 [Service]
@@ -9,4 +9,3 @@ RestartSec=5
 
 [Install]
 WantedBy=default.target
-


### PR DESCRIPTION
**Primary Changes:**
- Updated IPC method to align with with polybar version 3.6 IPC changes which require the use of polybar-msg.
Addresses #36 .
- The listener service can now detect Spotify on launch/reload of the service or if Spotify is launched while the service is running.

**Minor Changes:**
- Some additional debug statements were added for verbosity.
- Minor adjustments to a couple of debug statements for clarity.

**Bug-fixes:**
- Fixed a bug which prevented the module hooks from running until the track was changed at least once.
- Fixed a bug where only only some hooks were updated on property change. At launch, in combination with the other bug resulted in a partially rendered module until the user executed all 3 types of playback actions (Play/Pause, Next, Previous)