### PR TITLE
IPC Updates and Minor Bugfies (Revised)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .vgcore.*
 bin/
 obj/
+
+# added for clang diagnostics
+compile_commands.json
+.cache

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Next, add the following spotify modules:
 ```
 [module/previous]
 type = custom/ipc
+format = <output>
 format-font = 2
 ; Default
 hook-0 = echo ""
@@ -98,6 +99,7 @@ click-left = "spotifyctl -q previous"
 
 [module/next]
 type = custom/ipc
+format = <output>
 format-font = 2
 ; Default
 hook-0 = echo ""
@@ -108,6 +110,7 @@ click-left = "spotifyctl -q next"
 
 [module/playpause]
 type = custom/ipc
+format = <output>
 format-font = 2
 ; Default
 hook-0 = echo ""
@@ -120,6 +123,7 @@ click-left = "spotifyctl -q playpause"
 
 [module/spotify]
 type = custom/ipc
+format = <output>
 ; Default
 hook-0 = echo ""
 ; Playing/paused show song name and artist

--- a/include/spotify-listener.h
+++ b/include/spotify-listener.h
@@ -114,16 +114,16 @@ dbus_bool_t spotify_update_track(const char *current_trackid);
  * interface org.mpris.MediaPlayer2 for 'Spotify'
  * @returns dbus_bool_t TRUE if Spotify is current player, FALSE otherwise
  */
-dbus_bool_t get_spotify_status(GDBusConnection *conn);
+dbus_bool_t get_spotify_status();
 
 /**
- * Connect to dbus using a gio proxy and query the Metadata property of the bus
+ * Connect to dbus, and use a gio proxy to query the Metadata prop. of the bus
  * interface org.mpris.MediaPlayer2.Player.
  * Calls spotify_playing() or spotify_paused() as appropriate to set hooks
  * in the module.
  * @returns char* <trackid> of from Metadata for use in updates or a null*
  * if unable to get <trackid>
  */
-const char* get_now_playing(GDBusConnection *conn);
+const char* get_now_playing();
 
 #endif

--- a/include/spotify-listener.h
+++ b/include/spotify-listener.h
@@ -12,7 +12,7 @@
  *
  * @returns dbus_bool_t TRUE if messages successfully sent, FALSE otherwise.
  */
-dbus_bool_t send_ipc_polybar(int numOfMsgs, ...);
+dbus_bool_t send_polybar_msg(int numOfMsgs, ...);
 
 /**
  * DBus handler function for PropertiesChanged signals. This is automatically

--- a/include/spotify-listener.h
+++ b/include/spotify-listener.h
@@ -2,6 +2,9 @@
 #define _SPOTIFY_LISTENER_H_
 
 #include <dbus-1.0/dbus/dbus.h>
+#include <glib-2.0/glib.h>
+#include <glib-2.0/gio/gio.h>
+#include <glib-2.0/glib-object.h>
 #include <stdarg.h>
 
 /**
@@ -105,5 +108,22 @@ dbus_bool_t update_last_trackid(const char *trackid);
  * @returns dbus_bool_t TRUE if the trackid has changed, FALSE otherwise
  */
 dbus_bool_t spotify_update_track(const char *current_trackid);
+
+/**
+ * Connect to dbus using a gio proxy and check the Identity property of the bus
+ * interface org.mpris.MediaPlayer2 for 'Spotify'
+ * @returns dbus_bool_t TRUE if Spotify is current player, FALSE otherwise
+ */
+dbus_bool_t get_spotify_status(GDBusConnection *conn);
+
+/**
+ * Connect to dbus using a gio proxy and query the Metadata property of the bus
+ * interface org.mpris.MediaPlayer2.Player.
+ * Calls spotify_playing() or spotify_paused() as appropriate to set hooks
+ * in the module.
+ * @returns char* <trackid> of from Metadata for use in updates or a null*
+ * if unable to get <trackid>
+ */
+const char* get_now_playing(GDBusConnection *conn);
 
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
-LIBS := dbus-1
-CFLAGS = $(shell pkg-config --cflags dbus-1)
+LIBS := dbus-1 gio-2.0 glib-2.0
+CFLAGS = $(shell pkg-config --cflags dbus-1 gio-2.0 glib-2.0)
 
 LIBS_INC := $(foreach lib,$(LIBS),-l$(lib))
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,11 @@
 CC = gcc
 LIBS := dbus-1 gio-2.0 glib-2.0
-CFLAGS = $(shell pkg-config --cflags dbus-1 gio-2.0 glib-2.0)
+CFLAGS = $(shell pkg-config --cflags --libs dbus-1 gio-2.0 glib-2.0)
 
 LIBS_INC := $(foreach lib,$(LIBS),-l$(lib))
 
 PKG_NAME = polybar-spotify-module
-BASE_INSTALL_PREFIX = 
+BASE_INSTALL_PREFIX =
 
 IDIR = ../include
 ODIR = ../obj
@@ -43,7 +43,7 @@ all: spotifyctl spotify-listener
 debug: spotifyctl spotify-listener
 
 install: spotifyctl spotify-listener
-	install -Dm755 -t $(BASE_INSTALL_PREFIX)$(BIN_INSTALL_DIR) $(EXES) 
+	install -Dm755 -t $(BASE_INSTALL_PREFIX)$(BIN_INSTALL_DIR) $(EXES)
 	install -Dm644 $(LICENSE_FILE) $(BASE_INSTALL_PREFIX)$(LICENSE_INSTALL_PATH)
 	install -Dm644 $(README_FILE) $(BASE_INSTALL_PREFIX)$(README_INSTALL_PATH)
 	install -Dm644 $(SERVICE_FILE_NAME) $(BASE_INSTALL_PREFIX)$(SERVICE_INSTALL_PATH)
@@ -76,4 +76,3 @@ $(ODIR)/%.o: %.c $(DEPS) $(EXE_DEPS)
 
 clean:
 	rm -f $(ODIR)/*.o *~ core vgcore.* $(IDIR)/*~ $(BIN_DIR)/*
-


### PR DESCRIPTION
Replaces PR ticket #38 as it was particularly unreadable due to formatting choices I initially made.
I went back and revised my changes into a new fork. Having a moment to carefully pick through my original additions, I have revised them a decent amount as well, including improving the new polybar-msg routine error handling.

I was careful this time to avoid making formatting changes which might cause an excessive diff. Thank you for the feedback! Please try this fork and let me know if anything needs to be fixed/improved.

**The following major changes are proposed for merge:**

- Updated IPC method to align with with polybar version 3.6 IPC changes which require the use of polybar-msg.
    Addresses #36 .
- Added an initialization check using gio (dbus) during which the listener service can now detect Spotify on service launch or restart.
- Add dependency of glib2, which provides gobject and gio, which enables the initialization checks. This can be reconstructed to work within low level dbus, I think, which would avoid the dependency but will be much more verbose.*
- Added a verbose debug statement to the name change handler and changed the name change handler to allow it to detect spotify taking control of the dbus interface. Because new_owner is the dbus sender id, we can also set that as soon as spotify starts instead of just on properties change.

**Bug-fixes:**
- Fixed a bug which prevented the module hooks from running until the track was changed at least once.
- Fixed a bug where only only some hooks were updated on property change. At launch, in combination with the other bug resulted in a partially rendered module until the user executed all 3 types of playback actions (Play/Pause, Next, Previous)

*edited